### PR TITLE
Comment out CLICOLOR_FORCE=1 with warning

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -7,7 +7,7 @@
 # Colors.
 unset LSCOLORS
 export CLICOLOR=1
-export CLICOLOR_FORCE=1
+# export CLICOLOR_FORCE=1 # uncomment only if absolutely necessary -- as it can cause issues with `opam install topkg`, `ocamlfind` and anywhere else shell output is captured
 
 # Don't require escaping globbing characters in zsh.
 unsetopt nomatch


### PR DESCRIPTION
CLICOLOR_FORCE=1 can cause issues where shell output is captured -- such as with `opam install topkg`, `ocamlfind` and anywhere else shell output is captured.  Included warning about uncommenting this line